### PR TITLE
remove argparse that is not used

### DIFF
--- a/lib/ansible/modules/files/xml_operation.py
+++ b/lib/ansible/modules/files/xml_operation.py
@@ -111,7 +111,6 @@ xml_file:
 
 import os
 import sys
-import argparse
 try:
    from lxml import etree
 except ImportError as e:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Remove import argparse because it's is not used at the module. It was added at the very begin when module was run via console.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - New Module Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
